### PR TITLE
feat: Replace Phi-2 with Gemma and optimize performance

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import logging
 from utils.file_handling import save_uploaded_file
 
 # --- Constants and Configuration ---
-MODEL_NAME = "microsoft/phi-2"  # 2.7B params, fast
+MODEL_NAME = "google/gemma-3-1b-it"  # 1B params, fast, large context window
 
 # --- Logging Configuration ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
Replaced the `microsoft/phi-2` model with `google/gemma-3-1b-it` to improve performance on low-end hardware. The new model is smaller, faster, and has a larger context window.

Optimized the RAG chain by:
- Using `bfloat16` for faster CPU inference.
- Increasing the context truncation length to 8192 to better leverage the new model's capabilities.
- Updating the default model in the RAGChain class.